### PR TITLE
temporarily disable Planning Suite menu-option

### DIFF
--- a/src/components/pageStructure/header/NavigationMenu.tsx
+++ b/src/components/pageStructure/header/NavigationMenu.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { useNavigate } from 'react-router';
-import { GRAND_FOYER, HOUSEKEEPING, LEARNING, PLANNING, SHOWCASING } from '../../../routes/routes';
+import { GRAND_FOYER, HOUSEKEEPING, LEARNING, /*PLANNING,*/ SHOWCASING } from '../../../routes/routes';
 import { MenuIconContainer, XBar1, XBar2, XBar3 } from '../../menu/Menu.styles';
 import { MenuDropdownContainer, MenuDropdownItem } from '../../menu/MenuDropdown.styles';
 import { P } from '../../core/typography';

--- a/src/components/pageStructure/header/NavigationMenu.tsx
+++ b/src/components/pageStructure/header/NavigationMenu.tsx
@@ -61,14 +61,14 @@ const NavigationMenu = () => {
             <P>Showcasing suite</P>
           </MenuDropdownItem>
 
-          <MenuDropdownItem
+          {/* <MenuDropdownItem
             isPath={pathMatch(PLANNING)}
             onClick={() => {
               toggleHamburger();
               navigate(PLANNING);
             }}>
             <P>Planning suite</P>
-          </MenuDropdownItem>
+          </MenuDropdownItem> */}
 
           <MenuDropdownItem
             isPath={pathMatch(HOUSEKEEPING)}


### PR DESCRIPTION
To resolve the Planning Suite;
+ `year` will need to be added to the constants as the new year of 2024 broke the page
+ content coverage filled out for the missing months
+ I'd also like to add a date-picker feature at the top for convenience.